### PR TITLE
Disabling click to move function when clicking on chat and Info in lobby

### DIFF
--- a/src/components/Lobby/index.js
+++ b/src/components/Lobby/index.js
@@ -89,7 +89,10 @@ const MovementControls = ({ positionRef, transformControlsRef, peers }) => {
 
   useEffect(() => {
     const onPointerDown = (e) => {
-      pointerDownRef.current = true;
+      // Only set pointer down if clicking on the canvas element
+      if (e.target.tagName.toLowerCase() === 'canvas') {
+        pointerDownRef.current = true;
+      }
     };
 
     const onPointerMove = (e) => {


### PR DESCRIPTION
Only set pointer down if clicking on the canvas element, so clicking ShowInfoPanel or Chat won't move the avatar.